### PR TITLE
Add a dark version of the github syntax colors

### DIFF
--- a/colors/github-dark.vim
+++ b/colors/github-dark.vim
@@ -17,19 +17,21 @@ if version > 580
     endif
 endif
 
-let colors_name = "github"
+let colors_name = "github-dark"
 
 " {{{ General colors
-hi Normal   ctermfg=grey ctermbg=black guifg=#000000   guibg=#F8F8FF
-hi Cursor   ctermfg=239   ctermbg=15  guifg=#F8F8FF   guibg=#444454
+"hi Normal   ctermfg=0   ctermbg=255  guifg=grey   guibg=#F8F8FF
+hi Normal   ctermfg=grey ctermbg=black guifg=grey guibg=black
+hi Cursor   ctermfg=239   ctermbg=15  guifg=#F8F8FF   guibg=black
 hi Visual   ctermfg=15   ctermbg=61  guifg=#FFFFFF   guibg=#3465a3
 hi VisualNOS   ctermfg=15   ctermbg=24  guifg=#FFFFFF   guibg=#204a87
-hi Search   ctermfg=236   ctermbg=228  guifg=#000000   guibg=#FFFF8C  cterm=bold gui=bold
-hi Folded   ctermfg=grey ctermbg=237 guifg=#808080 guibg=#ECECEC gui=bold cterm=bold
+hi Search   ctermfg=236   ctermbg=228  guifg=grey   guibg=#FFFF8C  cterm=bold gui=bold
+hi Folded   ctermfg=grey ctermbg=237 guifg=grey guibg=#3a3a3a gui=bold cterm=bold
 hi Title    ctermfg=167 guifg=#ef5939
 hi StatusLine ctermfg=238 ctermbg=250 guifg=#404040 guibg=#bbbbbb gui=bold cterm=bold
 hi StatusLineNC ctermfg=238 ctermbg=252 guifg=#404040 guibg=#d4d4d4 gui=italic cterm=italic
 hi VertSplit ctermfg=250 ctermbg=250 guifg=#bbbbbb guibg=#bbbbbb gui=none cterm=none
+"hi LineNr   ctermfg=246 ctermbg=15 guifg=#959595 guibg=#ECECEC gui=bold cterm=bold
 hi SpecialKey ctermfg=6 guifg=#177F80 gui=italic cterm=italic
 hi WarningMsg ctermfg=167 guifg=#ef5939
 hi ErrorMsg ctermbg=15 ctermfg=196 guibg=#f8f8ff guifg=#ff1100 gui=undercurl cterm=undercurl
@@ -38,20 +40,20 @@ hi ColorColumn ctermbg=254 guibg=#e4e4e4
 
 " {{{ Vim => 7.0 specific colors
 if version >= 700
-    hi CursorLine ctermfg=white ctermbg=237 guibg=#D8D8DD
-    hi MatchParen ctermfg=0 ctermbg=252 guifg=#000000 guibg=#cdcdfd
+    hi CursorLine ctermbg=237 guibg=#3a3a3a
+    hi MatchParen ctermfg=0 ctermbg=252 guifg=grey guibg=#cdcdfd
     hi Pmenu        ctermfg=15 ctermbg=8 guifg=#ffffff guibg=#808080 gui=bold   cterm=bold
-    hi PmenuSel     ctermfg=0 ctermbg=252 guifg=#000000 guibg=#cdcdfd  gui=italic cterm=italic
-    hi PmenuSbar    ctermfg=238 ctermbg=0 guifg=#444444 guibg=#000000
+    hi PmenuSel     ctermfg=0 ctermbg=252 guifg=grey guibg=#cdcdfd  gui=italic cterm=italic
+    hi PmenuSbar    ctermfg=238 ctermbg=0 guifg=#444444 guibg=grey
     hi PmenuThumb   ctermfg=248 ctermbg=248 guifg=#aaaaaa guibg=#aaaaaa
 endif
 " }}}
 
 " {{{ Diff highlighting
-hi DiffAdd    ctermfg=white ctermbg=234 guifg=#003300 guibg=#DDFFDD gui=none cterm=none
-hi DiffChange ctermbg=234  guibg=#ececec gui=none   cterm=none
-hi DiffText   ctermfg=white ctermbg=234 guifg=#000033 guibg=#DDDDFF gui=none cterm=none
-hi DiffDelete ctermfg=160 ctermbg=234 guifg=#DDCCCC guibg=#FFDDDD gui=none    cterm=none
+hi DiffAdd    ctermfg=white ctermbg=234 guifg=white guibg=#1c1c1c gui=none cterm=none
+hi DiffChange ctermbg=234  guibg=#1c1c1c gui=none   cterm=none
+hi DiffText   ctermfg=white ctermbg=234 guifg=white guibg=#1c1c1c gui=none cterm=none
+hi DiffDelete ctermfg=160 ctermbg=234 guifg=#d70000 guibg=#1c1c1c gui=none    cterm=none
 " }}}
 
 " {{{ Syntax highlighting
@@ -62,16 +64,16 @@ hi Comment  ctermfg=246 guifg=#999988
 hi Constant ctermfg=6 guifg=#177F80 gui=none cterm=none
 hi String   ctermfg=161 guifg=#D81745
 hi Function ctermfg=88 guifg=#990000 gui=bold cterm=bold
-hi Statement    ctermfg=0 guifg=#000000 gui=bold cterm=bold
+hi Statement    ctermfg=0 guifg=grey gui=bold cterm=bold
 hi Type     ctermfg=60 guifg=#445588 gui=bold   cterm=bold
 hi Number   ctermfg=30 guifg=#1C9898
 hi Todo     ctermfg=15 ctermbg=88 guifg=#FFFFFF guibg=#990000 gui=bold cterm=bold
 hi Special  ctermfg=28 guifg=#159828 gui=bold   cterm=bold
 hi Todo         ctermbg=15 ctermfg=196 guibg=#f8f8ff guifg=#ff1100 gui=underline cterm=underline
-hi Label        ctermfg=0 guifg=#000000 gui=bold    cterm=bold
-hi StorageClass ctermfg=0 guifg=#000000 gui=bold    cterm=bold
-hi Structure    ctermfg=0 guifg=#000000 gui=bold    cterm=bold
-hi TypeDef      ctermfg=0 guifg=#000000 gui=bold    cterm=bold
+hi Label        ctermfg=0 guifg=grey gui=bold    cterm=bold
+hi StorageClass ctermfg=0 guifg=grey gui=bold    cterm=bold
+hi Structure    ctermfg=0 guifg=grey gui=bold    cterm=bold
+hi TypeDef      ctermfg=0 guifg=grey gui=bold    cterm=bold
 
 " {{{ Links
 hi! link FoldColumn Folded


### PR DESCRIPTION
A lot of us use a dark scheme.. and are bereft of the git colors you have in this repo. I just modified a bit, for dark themes. 
